### PR TITLE
chore(targetSdk): bump android target SDK to 36

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,12 +24,12 @@ if (keystorePropertiesFile.exists()) {
 
 android {
     namespace 'com.xpeho.xpeapp'
-    compileSdk 34
+    compileSdk 36
 
     defaultConfig {
         applicationId "com.xpeho.xpeapp"
         minSdk 26
-        targetSdk 34
+        targetSdk 36
         versionCode project.hasProperty('versionCode') ? project.versionCode.toInteger() : 1
         versionName project.hasProperty('versionName') ? project.versionName : "1.0"
 


### PR DESCRIPTION
This pull request updates the `app/build.gradle` file to improve compatibility and functionality by upgrading the SonarQube plugin and increasing the SDK versions.

### Plugin updates:
* Updated the SonarQube plugin from version `4.2.1.3168` to `6.2.0.5505` for improved analysis capabilities. (`[app/build.gradleL6-R6](diffhunk://#diff-51a0b488f963eb0be6c6599bf5df497313877cf5bdff3950807373912ac1cdc9L6-R6)`)

### SDK version upgrades:
* Increased `compileSdk` version from `34` to `36` to support newer Android features. (`[app/build.gradleL27-R32](diffhunk://#diff-51a0b488f963eb0be6c6599bf5df497313877cf5bdff3950807373912ac1cdc9L27-R32)`)
* Increased `targetSdk` version from `34` to `36` to ensure compatibility with the latest Android platform. (`[app/build.gradleL27-R32](diffhunk://#diff-51a0b488f963eb0be6c6599bf5df497313877cf5bdff3950807373912ac1cdc9L27-R32)`)