### PR TITLE
feat(newsletter): implement image fetching from WordPress storage

### DIFF
--- a/app/src/main/java/com/xpeho/xpeapp/data/service/FirebaseService.kt
+++ b/app/src/main/java/com/xpeho/xpeapp/data/service/FirebaseService.kt
@@ -1,13 +1,9 @@
 package com.xpeho.xpeapp.data.service
 
-import android.graphics.BitmapFactory
 import android.util.Log
-import androidx.compose.ui.graphics.ImageBitmap
-import androidx.compose.ui.graphics.asImageBitmap
 import com.google.firebase.FirebaseException
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
-import com.google.firebase.storage.FirebaseStorage
 import com.xpeho.xpeapp.data.FEATURE_FLIPPING_COLLECTION
 import com.xpeho.xpeapp.data.NEWSLETTERS_COLLECTION
 import com.xpeho.xpeapp.data.model.FeatureFlipping
@@ -84,20 +80,4 @@ class FirebaseService {
         return newslettersList.sortedByDescending { it.date }
     }
 
-    suspend fun getLastNewsletterPreview(previewPath: String?): ImageBitmap? {
-        var imageBitmap: ImageBitmap? = null
-
-        if (previewPath != null) {
-            try {
-                val storageRef = FirebaseStorage.getInstance().reference.child(previewPath)
-                val bytes = storageRef.getBytes(Long.MAX_VALUE).await()
-                val bitmap = BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
-                imageBitmap = bitmap.asImageBitmap()
-            } catch (e: FirebaseException) {
-                Log.e("getLastNewsletterPreview", "Error fetching image: ", e)
-            }
-        }
-
-        return imageBitmap
-    }
 }

--- a/app/src/main/java/com/xpeho/xpeapp/data/service/WordpressRepository.kt
+++ b/app/src/main/java/com/xpeho/xpeapp/data/service/WordpressRepository.kt
@@ -325,6 +325,26 @@ class WordpressRepository(
         )
     }
 
+    /// Storage features methods
+    // getImage
+    suspend fun getImage(imageName: String): ByteArray? {
+        return handleServiceExceptions(
+            tryBody = {
+                val response = api.fetchImageStorage(imageName)
+                if (response.isSuccessful) {
+                    response.body()?.bytes()
+                } else {
+                    null
+                }
+            },
+            catchBody = { e ->
+                Log.e("WordpressRepository: getImage", "Network error: ${e.message}")
+                null
+            }
+        )
+    }
+
+
     // Exceptions handling
 
     @Suppress("ReturnCount")

--- a/app/src/main/java/com/xpeho/xpeapp/data/service/WordpressService.kt
+++ b/app/src/main/java/com/xpeho/xpeapp/data/service/WordpressService.kt
@@ -107,5 +107,10 @@ interface WordpressService {
         @Query("page") page: String = "",
         ): List<AgendaBirthday>
 
+    // Storage Feature
+    // Fetch images from storage
+    @GET("xpeho/v1/image-storage/{imageName}")
+    suspend fun fetchImageStorage(
+        @Path("imageName", encoded = true) imageName: String,
+    ): Response<okhttp3.ResponseBody>
 }
-


### PR DESCRIPTION
# New change proposal

Thank you for contributing to XpeApp Android

This pull request refactors the way newsletter preview images are fetched and displayed. Instead of retrieving images directly from Firebase Storage in the `FirebaseService`, the logic now fetches images via the WordPress API using the `WordpressRepository`. The main changes include removing the image-fetching method from `FirebaseService`, introducing new methods in `WordpressRepository` and `WordpressService` to fetch images from WordPress, and updating the `NewsletterViewModel` to use this new approach.

# Change category

- [X] Feature

# Description

**Newsletter image fetching refactor:**

* Removed the `getLastNewsletterPreview` method from `FirebaseService`, eliminating direct Firebase Storage access for newsletter images.
* Added a new `getImage` method to `WordpressRepository` to fetch image bytes from the WordPress API, including error handling.
* Updated `WordpressService` with a new endpoint method `fetchImageStorage` to retrieve images from the WordPress backend.
* Modified `NewsletterViewModel` to use `WordpressRepository.getImage` for fetching and decoding newsletter preview images, replacing the old Firebase-based logic.

**Code cleanup and dependency updates:**

* Removed unused imports from `FirebaseService` and added necessary imports to `NewslettersViewModel` for image decoding and logging.

# Screenshots (if any)

Image with the actual Newsletter and picture in the table local.
<img width="216" height="215" alt="image" src="https://github.com/user-attachments/assets/9e05af6f-9e83-41c6-9ae5-3b22ae043dee" />


# Checklist

- [X] I have tested my changes in local using android mobile physical
- [X] The previous tests still works
- [X] I did not broke anything to ensure reverse compatibility
- [ ] README updated
