### PR TITLE
hotfix(QVSTCannotBeApproved): change the padding on Next and previous…

### DIFF
--- a/app/src/main/java/com/xpeho/xpeapp/ui/page/qvst/QvstCampaignDetail.kt
+++ b/app/src/main/java/com/xpeho/xpeapp/ui/page/qvst/QvstCampaignDetail.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
@@ -166,6 +167,7 @@ fun QvstCampaignDetailPage(
                             modifier = Modifier
                                 .padding(bottom = 10.dp, top = 5.dp)
                                 .fillMaxWidth()
+                                .safeDrawingPadding()
                         ) {
                             // Previous button
                             Icon(
@@ -177,7 +179,6 @@ fun QvstCampaignDetailPage(
                                     XpehoColors.DISABLED_COLOR
                                 },
                                 modifier = Modifier
-                                    .padding(24.dp) // Increase touch area
                                     .clickable(onClick = {
                                         if (currentQuestionIndex.value > 0) {
                                             currentQuestionIndex.value -= 1
@@ -208,7 +209,6 @@ fun QvstCampaignDetailPage(
                                     XpehoColors.DISABLED_COLOR
                                 },
                                 modifier = Modifier
-                                    .padding(24.dp) // Increase touch area
                                     .size(
                                         if (currentQuestionIndex.value < questions.size) {
                                             24.dp


### PR DESCRIPTION
… button

# New change proposal

Thank you for contributing to XpeApp Android

In order to response of QVST Campaign, our collaborator Jean-Baptiste was blocked by this screen because the navigation gesture block the access of buttons

# Change category

- [X] Hotfix

# Description

<!-- Put a full  description of your modifications -->

# Screenshots (if any)

Phone of JB Before: 
<img width="371" height="828" alt="image" src="https://github.com/user-attachments/assets/d11fe965-dc3d-4095-8173-232ebe61ee43" />

Phone after: 
<img width="398" height="108" alt="image" src="https://github.com/user-attachments/assets/dbb42e93-3618-40ef-a197-1694595bcef7" />


# Checklist

- [x] I have tested my changes
- [ ] The previous tests still works
- [ ] I did not broke anything to ensure reverse compatibility
- [ ] README updated
